### PR TITLE
fix: edit rubric link to go to membership tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     <div class="content-container">
       <h1>LINUX SOCIETY</h1>
       <div class="content-list">
-        <a href="https://campus.hellorubric.com/?s=12591">
+       <a href="https://campus.hellorubric.com/?tab=memberships&s=12591">
           <h1>RUBRIC</h1>
         </a>
         <a href="https://discord.gg/7Tqz2bn8Gz">


### PR DESCRIPTION
changes rubric link on the site to point directly to memberships tab instead of events